### PR TITLE
Remove securehash

### DIFF
--- a/scram.nimble
+++ b/scram.nimble
@@ -1,4 +1,4 @@
-version       = "0.1.2"
+version       = "0.1.3"
 author        = "Huy Doan"
 description   = "Salted Challenge Response Authentication Mechanism (SCRAM) "
 license       = "MIT"

--- a/scram/client.nim
+++ b/scram/client.nim
@@ -1,4 +1,4 @@
-import base64, pegs, random, strutils, hmac, nimSHA2, securehash, md5, private/[utils,types]
+import base64, pegs, random, strutils, hmac, sha1, nimSHA2, md5, private/[utils,types]
 
 export MD5Digest, SHA1Digest, SHA256Digest, SHA512Digest
 

--- a/scram/server.nim
+++ b/scram/server.nim
@@ -1,4 +1,4 @@
-import base64, pegs, random, strutils, hmac, nimSHA2, securehash, md5, private/[utils,types]
+import base64, pegs, random, strutils, hmac, sha1, nimSHA2, md5, private/[utils,types]
 
 type
   ScramServer*[T] = ref object of RootObj


### PR DESCRIPTION
Since `securehash` is gone, I suggest switching to `sha1` package.

Depends on https://github.com/onionhammer/sha1/pull/4 and https://github.com/OpenSystemsLab/hmac.nim/pull/4