### PR TITLE
Fix scram not compiling

### DIFF
--- a/scram/private/utils.nim
+++ b/scram/private/utils.nim
@@ -15,7 +15,7 @@ template makeNonce*(): string =
 
 template `^=`*[T](a, b: T) =
   for x in 0..<a.len:
-    when T is Sha1Digest or T is Keccak512Digest:
+    when T is Sha1Digest or T is Keccak512Digest or T is SHA256Digest:
       a[x] = (a[x].int32 xor b[x].int32).uint8
     else:
       a[x] = (a[x].int32 xor b[x].int32).char


### PR DESCRIPTION
Fix this error:

```
/home/mildred/.nimble/pkgs/scram-0.1.13/scram/server.nim(28, 24) template/generic instantiation of `hi` from here
/home/mildred/.nimble/pkgs/scram-0.1.13/scram/private/utils.nim(54, 12) template/generic instantiation of `^=` from here
/home/mildred/.nimble/pkgs/scram-0.1.13/scram/private/utils.nim(21, 41) Error: type mismatch: got 'char' for 'char(int32(result[x`gensym2]) xor int32(previous[x`gensym2]))' but expected 'uint8'
```