### PR TITLE
Lift the repo to nim2

### DIFF
--- a/scram.nimble
+++ b/scram.nimble
@@ -3,4 +3,4 @@ author        = "Huy Doan"
 description   = "Salted Challenge Response Authentication Mechanism (SCRAM) "
 license       = "MIT"
 
-requires "nim >= 0.19.4", "hmac >= 0.2.0"
+requires "nim >= 0.19.4", "hmac >= 0.2.0", "checksums >= 0.1.0"

--- a/scram/client.nim
+++ b/scram/client.nim
@@ -1,4 +1,5 @@
-import base64, strformat, strutils, hmac, sha1, nimSHA2, md5, private/[utils,types]
+import base64, strformat, strutils, hmac, nimSHA2, private/[utils,types]
+import checksums/[sha1, md5]
 
 export MD5Digest, SHA1Digest, SHA224Digest, SHA256Digest, SHA384Digest, SHA512Digest, Keccak512Digest
 export getChannelBindingData
@@ -69,10 +70,7 @@ proc prepareFinalMessage*[T](s: ScramClient[T], password, serverFirstMessage: st
   var clientProof = clientKey
   clientProof ^= clientSignature
   s.state = FINAL_PREPARED
-  when NimMajor >= 1 and (NimMinor >= 1 or NimPatch >= 2):
-    clientFinalMessageWithoutProof & ",p=" & base64.encode(clientProof)
-  else:
-    clientFinalMessageWithoutProof & ",p=" & base64.encode(clientProof, newLine="")
+  clientFinalMessageWithoutProof & ",p=" & base64.encode(clientProof)
 
 proc verifyServerFinalMessage*(s: ScramClient, serverFinalMessage: string): bool =
   if s.state != FINAL_PREPARED:

--- a/scram/private/utils.nim
+++ b/scram/private/utils.nim
@@ -1,6 +1,6 @@
 import random, base64, strutils, types, hmac, bitops, openssl, net, asyncnet
-from md5 import MD5Digest
-from sha1 import Sha1Digest
+from checksums/md5 import MD5Digest
+from checksums/sha1 import Sha1Digest
 from nimSHA2 import Sha224Digest, Sha256Digest, Sha384Digest, Sha512Digest
 
 
@@ -29,10 +29,10 @@ proc X509_get_signature_nid(x: PX509): int32
 proc OBJ_find_sigid_algs(signature: int32, pdigest: pointer, pencryption: pointer): int32
 proc OBJ_nid2sn(n: int): cstring
 
-proc EVP_sha256(): PEVP_MD
-proc EVP_get_digestbynid(): PEVP_MD
+proc EVP_sha256(): EVP_MD
+proc EVP_get_digestbynid(): EVP_MD
 
-proc X509_digest(data: PX509, kind: PEVP_MD, md: ptr char, len: ptr uint32): int32
+proc X509_digest(data: PX509, kind: EVP_MD, md: ptr char, len: ptr uint32): int32
 
 {.pop.}
 
@@ -167,7 +167,7 @@ proc getChannelBindingData*(channel: ChannelType, socket: AnySocket, isServer = 
     var
       serverCert: PX509
       algoNid: int32
-      algoType: PEVP_MD
+      algoType: EVP_MD
       hash: array[EVP_MAX_MD_SIZE, char]
       hashSize: int32
 

--- a/scram/server.nim
+++ b/scram/server.nim
@@ -1,4 +1,5 @@
-import base64, strformat, strutils, hmac, sha1, nimSHA2, md5, private/[utils,types]
+import base64, strformat, strutils, hmac, nimSHA2, private/[utils,types]
+import checksums/[sha1, md5]
 
 export MD5Digest, SHA1Digest, SHA224Digest, SHA256Digest, SHA384Digest, SHA512Digest, Keccak512Digest
 export getChannelBindingData
@@ -152,10 +153,7 @@ proc prepareFinalMessage*[T](s: ScramServer[T], clientFinalMessage: string): str
 
   s.isSuccessful = true
   s.state = ENDED
-  when NimMajor >= 1 and (NimMinor >= 1 or NimPatch >= 2):
-    result = "v=" & base64.encode(serverSignature)
-  else:
-    result = "v=" & base64.encode(serverSignature, newLine="")
+  result = "v=" & base64.encode(serverSignature)
 
 
 proc isSuccessful*(s: ScramServer): bool =

--- a/tests/test_both.nim
+++ b/tests/test_both.nim
@@ -1,4 +1,5 @@
-import unittest, scram/server, scram/client, sha1, nimSHA2, base64, scram/private/[utils,types]
+import unittest, scram/server, scram/client, nimSHA2, base64, scram/private/[utils,types]
+import checksums/sha1
 
 
 proc test[T](user, password: string) =

--- a/tests/test_cb.nim
+++ b/tests/test_cb.nim
@@ -1,4 +1,5 @@
-import unittest, scram/[server,client], sha1, nimSHA2
+import unittest, scram/[server,client], nimSHA2
+import checksums/sha1
 import scram/private/types
 
 const FAKE_CBDATA = "xxxxxxxxxxxxxxxx"

--- a/tests/test_server.nim
+++ b/tests/test_server.nim
@@ -1,4 +1,5 @@
-import unittest, scram/server, sha1, nimSHA2, base64
+import unittest, scram/server, nimSHA2, base64
+import checksums/sha1
 import scram/private/[utils, types]
 
 proc test[T](user, password, nonce, salt, cfirst, sfirst, cfinal, sfinal: string) =


### PR DESCRIPTION
- use sha1 and md5 from checksums
- PEVP_MD to EVP_MD
- 
![image](https://github.com/ba0f3/scram.nim/assets/4949069/9fd4eb94-7dbc-428e-ae8e-9dff4f833a19)
